### PR TITLE
OEL-117: Update PHP >= 7.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,5 +77,4 @@ matrix:
     - lowest
     - highest
   PHP_VERSION:
-    - 7.2
     - 7.3

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "drupal/core": "^8.7",
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "require-dev": {
         "composer/installers": "~1.5",


### PR DESCRIPTION
## OEL-117

### Description

Update the php version to 7.3

### Change log

- Added: PHP 7.3
- Changed: PHP minimum version 7.3
- Deprecated: N/A
- Removed: PHP 7.2
- Fixed: N/A
- Security: N/A

### Commands
N/A

