### PR TITLE
OEL-60: Drupal 9 compatibility fixes.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,5 +77,4 @@ matrix:
     - lowest
     - highest
   PHP_VERSION:
-    - 7.2
     - 7.3

--- a/README.md
+++ b/README.md
@@ -21,8 +21,19 @@ composer install
 ```
 
 A post command hook (`drupal:site-setup`) is triggered automatically after `composer install`.
-It will make sure that the necessary symlinks are properly setup in the development site.
-It will also perform token substitution in development configuration files such as `behat.yml.dist`.
+This will symlink the module in the proper directory within the test site and perform token substitution in test configuration files such as `behat.yml.dist`.
+
+**Please note:** project files and directories are symlinked within the test site by using the
+[OpenEuropa Task Runner's Drupal project symlink](https://github.com/openeuropa/task-runner-drupal-project-symlink) command.
+
+If you add a new file or directory in the root of the project, you need to re-run `drupal:site-setup` in order to make
+sure they are be correctly symlinked.
+
+If you don't want to re-run a full site setup for that, you can simply run:
+
+```
+$ ./vendor/bin/run drupal:symlink-project
+```
 
 * Install test site by running:
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,7 +2,7 @@ default:
   suites:
     default:
       paths:
-        - %paths.base%/tests/features
+        - "%paths.base%/tests/features"
       contexts:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\DrupalContext

--- a/composer.json
+++ b/composer.json
@@ -6,22 +6,21 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.7",
-        "php": ">=7.2"
+        "drupal/core": "^8.9 || ^9.1",
+        "php": ">=7.3"
     },
     "require-dev": {
-        "composer/installers": "~1.5",
-        "drupal/core-composer-scaffold": "^8.8",
-        "drupal/config_devel": "~1.2",
-        "drupal/drupal-extension": "~4.0",
-        "drush/drush": "~9.0",
-        "guzzlehttp/guzzle": "~6.3",
-        "openeuropa/behat-transformation-context" : "~0.1",
-        "openeuropa/code-review": "~1.0@beta",
-        "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/task-runner": "~1.0@beta",
-        "openeuropa/oe_multilingual": "^1.1",
-        "phpunit/phpunit": "~6.0"
+        "composer/installers": "~1.11",
+        "drupal/core-composer-scaffold": "^8.9 || ^9.1",
+        "drupal/config_devel": "^1.8",
+        "drupal/drupal-extension": "^4.1",
+        "drush/drush": "^10.3",
+        "openeuropa/behat-transformation-context": "^0.1",
+        "openeuropa/code-review": "^1.6",
+        "openeuropa/drupal-core-require-dev": "^8.9 || ^9.1",
+        "openeuropa/task-runner-drupal-project-symlink": "^1.0",
+        "openeuropa/oe_multilingual": "^1.7",
+        "phpspec/prophecy-phpunit": "^1 || ^2"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/modules/oe_search_demo/oe_search_demo.info.yml
+++ b/modules/oe_search_demo/oe_search_demo.info.yml
@@ -1,3 +1,3 @@
 name: OpenEuropa Search Demo
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 type: module

--- a/oe_search.info.yml
+++ b/oe_search.info.yml
@@ -3,7 +3,7 @@ description: Search features for the OpenEuropa project.
 package: OpenEuropa
 
 type: module
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 'interface translation project': oe_search
 # The path to the actual translations is defined in

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true" >
+<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true"  cacheResult="false">
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>
@@ -8,7 +8,7 @@
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
   </php>
   <testsuites>
-    <testsuite>
+    <testsuite name="OE SEARCH Tests">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -36,7 +36,7 @@ drupal:
 
 commands:
   drupal:site-setup:
-    - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/oe_search" }
+    - { task: "run", command: "drupal:symlink-project" }
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
     - { task: "run", command: "setup:phpunit" }


### PR DESCRIPTION
## OEL-60

### Description

Add D9 compatibility. Prepare the oe_search module so it can be integrated inside oe_theme as development requirement.

### Change log

- Added: N/A
- Changed: 
    - Drone
    - README
    - composer.json
    - core_version_requirement on various info.yml files.
    - phpunit.xml.dist
    - Runner
- Deprecated: N/A
- Removed: N/A
- Fixed: N/A
- Security: N/A

