### PR TITLE
EWPP-6988: Trigger pipeline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   automated-tests:
-    uses: openeuropa/github-ci/.github/workflows/drupal-ci.yml@main
+    uses: openeuropa/github-ci/.github/workflows/drupal-ci.yml@EWPP-6988
     with:
       run_behat: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   automated-tests:
-    uses: openeuropa/github-ci/.github/workflows/drupal-ci.yml@EWPP-6988
+    uses: openeuropa/github-ci/.github/workflows/drupal-ci.yml@main
     with:
       run_behat: false

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
             "php-http/discovery": true,
             "phpro/grumphp-shim": true,
             "phpstan/extension-installer": true,
-            "tbachert/spi": false
+            "tbachert/spi": false,
+            "symfony/runtime": true
         }
     }
 }

--- a/tests/modules/oe_search_test/oe_search_test.info.yml
+++ b/tests/modules/oe_search_test/oe_search_test.info.yml
@@ -10,3 +10,4 @@ dependencies:
   - drupal:media
   - oe_search:oe_search
   - oe_search:oe_search_mock
+  - search_api:search_api_test_example_content

--- a/tests/src/Functional/LanguageFilterViewTest.php
+++ b/tests/src/Functional/LanguageFilterViewTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\oe_search\Functional;
 
+use Drupal\field\Entity\FieldConfig;
+use Drupal\node\Entity\NodeType;
 use Drupal\search_api\Entity\Index;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
@@ -25,6 +27,7 @@ class LanguageFilterViewTest extends BrowserTestBase {
     'locale',
     'language',
     'node',
+    'node_storage_body_field',
     'user',
     'media',
     'text',
@@ -33,7 +36,6 @@ class LanguageFilterViewTest extends BrowserTestBase {
     'views',
     'http_request_mock',
     'oe_search',
-    'oe_search_demo',
     'oe_search_mock',
   ];
 
@@ -47,6 +49,23 @@ class LanguageFilterViewTest extends BrowserTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    // The "europa_nodes" search index shipped by oe_search_demo indexes the
+    // node "body" field. Recent Drupal/search_api versions resolve the data
+    // definition of every indexed field when the index/view configuration is
+    // installed, so a node bundle exposing a "body" field must exist before
+    // oe_search_demo is installed. The "body" field storage is provided by the
+    // node_storage_body_field module (Drupal core 11.3+, contrib backport on
+    // older versions).
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+    FieldConfig::create([
+      'field_name' => 'body',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'Body',
+    ])->save();
+    \Drupal::service('module_installer')->install(['oe_search_demo']);
+
     // Save index to make sure view is correct.
     Index::load('europa_nodes')->save();
     ConfigurableLanguage::createFromLangcode('fr')->save();

--- a/tests/src/Kernel/BackendIngestionTest.php
+++ b/tests/src/Kernel/BackendIngestionTest.php
@@ -346,7 +346,7 @@ class BackendIngestionTest extends KernelTestBase {
     $boundary = $this->getRequestBoundary($request);
     $this->assertBoundary($request, $boundary);
     $parts = $this->getRequestMultipartStreamResources($request, $boundary);
-    $expected_meta = json_encode([
+    $expected_meta = [
       'SEARCH_API_ID' => [$item_id],
       'SEARCH_API_DATASOURCE' => ['entity:entity_test_mulrev_changed'],
       'SEARCH_API_LANGUAGE' => ['en'],
@@ -356,9 +356,9 @@ class BackendIngestionTest extends KernelTestBase {
       'name' => [$entity->label()],
       'created' => [$item->getField('created')->getValues()['0'] * 1000],
       'type' => [$entity->bundle()],
-    ]);
+    ];
 
-    $this->assertMultipartStreamResource($parts[0], 'application/json', 'metadata', strlen($expected_meta), $expected_meta);
+    $this->assertIngestedItemMetadata($parts[0], $expected_meta);
     $this->assertMultipartStreamResource($parts[1], 'text/plain', 'text', strlen($entity->label()), $entity->label());
   }
 
@@ -386,15 +386,35 @@ class BackendIngestionTest extends KernelTestBase {
     $boundary = $this->getRequestBoundary($request);
     $this->assertBoundary($request, $boundary);
     $parts = $this->getRequestMultipartStreamResources($request, $boundary);
-    $expected_meta = json_encode([
+    $expected_meta = [
       'SEARCH_API_ID' => [$item_id],
       'SEARCH_API_DATASOURCE' => ['entity:media'],
       'SEARCH_API_LANGUAGE' => ['en'],
       'SEARCH_API_SITE_HASH' => [Utility::getSiteHash()],
       'SEARCH_API_INDEX_ID' => [$this->indexId],
-    ]);
+    ];
 
-    $this->assertMultipartStreamResource($parts[0], 'application/json', 'metadata', strlen($expected_meta), $expected_meta);
+    $this->assertIngestedItemMetadata($parts[0], $expected_meta);
+  }
+
+  /**
+   * Asserts the JSON metadata part of an ingestion request.
+   *
+   * The order of the metadata fields depends on the order of the index field
+   * settings, which varies across Drupal core and Search API versions, so the
+   * decoded metadata is compared instead of the raw JSON string.
+   *
+   * @param string $part
+   *   The multipart stream resource.
+   * @param array $expected
+   *   The expected metadata values, keyed by field name.
+   */
+  protected function assertIngestedItemMetadata(string $part, array $expected): void {
+    [$headers, $content] = explode("\r\n\r\n", $part);
+    $headers = explode("\r\n", $headers);
+    $this->assertContains('Content-Type: application/json', $headers);
+    $this->assertContains('Content-Disposition: form-data; name="metadata"; filename="metadata"', $headers);
+    $this->assertEquals($expected, json_decode($content, TRUE));
   }
 
   /**

--- a/tests/src/Kernel/BackendSearchTest.php
+++ b/tests/src/Kernel/BackendSearchTest.php
@@ -8,9 +8,8 @@ use Drupal\Core\Site\Settings;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\TestFileCreationTrait;
 use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\Tests\oe_search\Traits\TestIndexFieldCreationTrait;
 use Drupal\Tests\search_api\Functional\ExampleContentTrait;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Entity\Server;
 use Drupal\search_api\Utility\Utility as SearchApiUtility;
@@ -30,6 +29,7 @@ class BackendSearchTest extends KernelTestBase {
   use AssertTestRequestTrait;
   use MediaTypeCreationTrait;
   use TestFileCreationTrait;
+  use TestIndexFieldCreationTrait;
 
   /**
    * A Search API index ID.
@@ -127,7 +127,6 @@ class BackendSearchTest extends KernelTestBase {
       'image',
       'search_api',
       'oe_search',
-      'oe_search_test',
       'user',
       'views',
     ]);
@@ -156,95 +155,15 @@ class BackendSearchTest extends KernelTestBase {
     ] + Settings::getAll();
     new Settings($settings);
 
-    $this->backend = Server::load('europa_search_server')->getBackend();
+    $this->createTestIndexFields();
+
+    // Install the test module config (search index + view) only after all the
+    // indexed fields exist. On Drupal 11.4+ installing the index/view config
+    // eagerly resolves the data definition of every indexed field, which would
+    // otherwise fail for the fields created programmatically above.
+    $this->installConfig(['oe_search_test']);
     $this->index = Index::load($this->indexId);
-    $this->createTestBundle('item', NULL, 'entity_test_mulrev_changed');
-    $this->createTestBundle('article', NULL, 'entity_test_mulrev_changed');
-
-    // Body.
-    FieldStorageConfig::create([
-      'field_name' => 'body',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'type' => 'text',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'body',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'item',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'body',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'article',
-    ])->save();
-
-    // Keywords.
-    FieldStorageConfig::create([
-      'field_name' => 'keywords',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'type' => 'text',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'keywords',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'item',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'keywords',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'article',
-    ])->save();
-
-    // Boolean.
-    FieldStorageConfig::create([
-      'field_name' => 'highlighted',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'type' => 'boolean',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'highlighted',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'item',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'highlighted',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'article',
-    ])->save();
-
-    // Date.
-    FieldStorageConfig::create([
-      'field_name' => 'publication_date',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'type' => 'datetime',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'publication_date',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'item',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'publication_date',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'article',
-    ])->save();
-
-    // Datetime.
-    FieldStorageConfig::create([
-      'field_name' => 'cron_time',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'type' => 'datetime',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'cron_time',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'item',
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'cron_time',
-      'entity_type' => 'entity_test_mulrev_changed',
-      'bundle' => 'article',
-    ])->save();
+    $this->backend = Server::load('europa_search_server')->getBackend();
   }
 
   /**
@@ -679,31 +598,6 @@ class BackendSearchTest extends KernelTestBase {
     $this->assertEquals('entity_test_mulrev_changed', $view->result[0]->_entity->getEntityTypeId());
     $this->assertEquals(11, $view->result[0]->_entity->id());
     $this->assertEquals('article 1', $view->result[0]->_entity->label());
-  }
-
-  /**
-   * Creates a new bundle for entity_test entities.
-   *
-   * @param string $bundle
-   *   The machine-readable name of the bundle.
-   * @param string|null $text
-   *   (optional) The human-readable name of the bundle. If none is provided,
-   *   the machine name will be used.
-   * @param string $entity_type
-   *   (optional) The entity type for which the bundle is created. Defaults to
-   *   'entity_test'.
-   *
-   * @todo Remove after drupal:12.0.0. Use
-   *    \Drupal\entity_test\EntityTestHelper::createBundle() instead.
-   *
-   * @see \Drupal\entity_test\Hook\EntityTestHooks::entityBundleInfo()
-   * /
-   */
-  protected function createTestBundle(string $bundle, ?string $text = NULL, string $entity_type = 'entity_test'): void {
-    $bundles = \Drupal::state()->get($entity_type . '.bundles', [$entity_type => ['label' => 'Entity Test Bundle']]);
-    $bundles += [$bundle => ['label' => $text ?: $bundle]];
-    \Drupal::state()->set($entity_type . '.bundles', $bundles);
-    \Drupal::service('entity_bundle.listener')->onBundleCreate($bundle, $entity_type);
   }
 
 }

--- a/tests/src/Kernel/QueryBuilderTest.php
+++ b/tests/src/Kernel/QueryBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_search\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\oe_search\Traits\TestIndexFieldCreationTrait;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Entity\Server;
 use Drupal\search_api\Query\ConditionGroup;
@@ -17,6 +18,8 @@ use Drupal\search_api\Query\Query;
  * @group oe_search
  */
 class QueryBuilderTest extends KernelTestBase {
+
+  use TestIndexFieldCreationTrait;
 
   /**
    * A Search API index ID.
@@ -62,6 +65,8 @@ class QueryBuilderTest extends KernelTestBase {
     'image',
     'file',
     'views',
+    'text',
+    'datetime',
   ];
 
   /**
@@ -82,9 +87,16 @@ class QueryBuilderTest extends KernelTestBase {
       'search_api',
       'system',
       'oe_search',
-      'oe_search_test',
       'views',
     ]);
+
+    // Create the bundles and fields referenced by the test search index before
+    // installing the index/view config. On Drupal 11.4+ installing that config
+    // eagerly resolves the data definition of every indexed field, which would
+    // otherwise fail because these fields do not exist yet.
+    $this->createTestIndexFields();
+
+    $this->installConfig(['oe_search_test']);
 
     $this->queryBuilder = $this->container->get('oe_search.query_expression_builder');
     $this->backend = Server::load('europa_search_server')->getBackend();

--- a/tests/src/Traits/TestIndexFieldCreationTrait.php
+++ b/tests/src/Traits/TestIndexFieldCreationTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_search\Traits;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Creates the bundles and fields required by the test search index.
+ */
+trait TestIndexFieldCreationTrait {
+
+  /**
+   * Creates the bundles and fields referenced by the test search index.
+   *
+   * The "europa_search_index" index shipped by oe_search_test indexes several
+   * fields of the "entity_test_mulrev_changed" entity type. Recent Drupal core
+   * versions resolve the data definition of every indexed field when the
+   * index/view configuration is installed, so the bundles and fields have to
+   * exist before installing the oe_search_test config.
+   */
+  protected function createTestIndexFields(): void {
+    $this->createTestBundle('item', NULL, 'entity_test_mulrev_changed');
+    $this->createTestBundle('article', NULL, 'entity_test_mulrev_changed');
+
+    $field_types = [
+      'body' => 'text',
+      'keywords' => 'text',
+      'highlighted' => 'boolean',
+      'publication_date' => 'datetime',
+      'cron_time' => 'datetime',
+    ];
+    foreach ($field_types as $field_name => $field_type) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'entity_test_mulrev_changed',
+        'type' => $field_type,
+      ])->save();
+      foreach (['item', 'article'] as $bundle) {
+        FieldConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'entity_test_mulrev_changed',
+          'bundle' => $bundle,
+        ])->save();
+      }
+    }
+  }
+
+  /**
+   * Creates a new bundle for entity_test entities.
+   *
+   * @param string $bundle
+   *   The machine-readable name of the bundle.
+   * @param string|null $text
+   *   (optional) The human-readable name of the bundle. If none is provided,
+   *   the machine name will be used.
+   * @param string $entity_type
+   *   (optional) The entity type for which the bundle is created. Defaults to
+   *   'entity_test'.
+   *
+   * @todo Remove after drupal:12.0.0. Use
+   *   \Drupal\entity_test\EntityTestHelper::createBundle() instead.
+   */
+  protected function createTestBundle(string $bundle, ?string $text = NULL, string $entity_type = 'entity_test'): void {
+    $bundles = \Drupal::state()->get($entity_type . '.bundles', [$entity_type => ['label' => 'Entity Test Bundle']]);
+    $bundles += [$bundle => ['label' => $text ?: $bundle]];
+    \Drupal::state()->set($entity_type . '.bundles', $bundles);
+    \Drupal::service('entity_bundle.listener')->onBundleCreate($bundle, $entity_type);
+  }
+
+}


### PR DESCRIPTION
## Summary

Recent Drupal core versions (11.4+) resolve the data definition of every indexed field as soon as a Search API index/view config is installed, but previously, this happened lazily. Our test indexes reference fields (`body`, `keywords`, `publication_date`, etc.) that the tests only created *after* installing that config, so setup failed with `Could not retrieve data definition for field 'Body'`.

### Changes

- **BackendSearchTest / QueryBuilderTest**: create the test bundles and all indexed fields *before* installing the `oe_search_test` config (index + view). The shared setup logic now lives in a new `TestIndexFieldCreationTrait`, which also carries the `createTestBundle()` backport (needed until Drupal 12, where core's `EntityTestHelper::createBundle()` replaces it).
- **LanguageFilterViewTest**: the `europa_nodes` index indexes the node `body` field, but no node type with a body field existed. The test now creates a node type with a body field first, then installs `oe_search_demo`. The body field storage comes from `node_storage_body_field` (core 11.3+, contrib backport on 10.x).
- **BackendIngestionTest**: the order of fields in the ingested JSON metadata varies across core/Search API versions. The assertion now compares the decoded metadata array (order-independent) instead of an exact JSON string.